### PR TITLE
Allow + characters in enskild firma.

### DIFF
--- a/Organisationsnummer.Tests/OrganisationsnummerTests.cs
+++ b/Organisationsnummer.Tests/OrganisationsnummerTests.cs
@@ -39,7 +39,8 @@ public class OrganisationsnummerTests
     public void TestFormatWithSeparator(OrganisationsnummerData input)
     {
         Assert.Equal(input.LongFormat, Organisationsnummer.Parse(input.LongFormat).Format(true));
-        Assert.Equal(input.LongFormat, Organisationsnummer.Parse(input.ShortFormat).Format(true));
+        // If short format in, we must presume it's not a + expected.
+        Assert.Equal(input.LongFormat.Replace('+', '-'), Organisationsnummer.Parse(input.ShortFormat).Format(true));
     }
 
     [Theory]

--- a/Organisationsnummer/Organisationsnummer.cs
+++ b/Organisationsnummer/Organisationsnummer.cs
@@ -141,6 +141,11 @@ namespace Organisationsnummer
         /// <returns></returns>
         public string Format(bool separator = true)
         {
+            if (IsPersonnummer)
+            {
+                return _personnummer!.Format(false, !separator);
+            }
+
             var num = ShortString;
             return separator ? $"{num!.Substring(0, 6)}-{num!.Substring(6)}" : num!;
         }
@@ -151,6 +156,7 @@ namespace Organisationsnummer
 
         private void InnerParse(string input)
         {
+            var originalInput = input;
             if (input.Length is > 13 or < 10)
             {
                 var state = input.Length > 13 ? "long" : "short";
@@ -197,7 +203,7 @@ namespace Organisationsnummer
             {
                 try
                 {
-                    _personnummer = PerNr.Parse(input);
+                    _personnummer = PerNr.Parse(originalInput);
                 }
                 catch
                 {


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Fixes an issue where organisationsnummer for enskild firma with an owners age above 100 would use the `-` separator.

**Related issue**

#38 

**Motivation**

Adhere to Skatteverkets standard.

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
