### PR TITLE
Updated target versions to net8, net9 and netstandard2.1

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,6 +31,13 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
 
+      # Required for now, due to auto script not using dotnet 9 yet.
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up dotnet.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 9.0.x
       - name: Build
         run: dotnet build --configuration Release Organisationsnummer -p:VersionPrefix=${{ github.event.release.tag_name }}
       - name: Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ ' 6.0.x' ]
+        dotnet: [ ' 9.0.x' ]
     name: Test dotnet ${{ matrix.dotnet-versions }}
     steps:
       - uses: actions/checkout@v4

--- a/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
+++ b/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Organisationsnummer/Organisationsnummer.csproj
+++ b/Organisationsnummer/Organisationsnummer.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net46;net47;net5.0;net6.0;net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>default</LangVersion>
         <Company>Organisationsnummer</Company>
         <Authors>Johannes Tegnér, Organisationsnummer Contributors</Authors>
         <Description>Verify Swedish Organisation numbers.</Description>


### PR DESCRIPTION
Update of targets to dotnet 8, 9 and netstandard2.1

This is a breaking change and should be released as a new major version (preferably including the updated personnummer package with new targets).

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.

