### PR TITLE
Updated target versions to include net9.

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,6 +31,13 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
 
+      # Required for now, due to auto script not using dotnet 9 yet.
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up dotnet.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 9.0.x
       - name: Build
         run: dotnet build --configuration Release Organisationsnummer -p:VersionPrefix=${{ github.event.release.tag_name }}
       - name: Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ ' 6.0.x' ]
-    name: Test dotnet ${{ matrix.dotnet-versions }}
+    name: Test dotnet
     steps:
       - uses: actions/checkout@v4
-      - name: Set up dotnet.
+      - name: Set up dotnet 7
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: '7.0.x'
+      - name: Set up dotnet 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Build
         run: dotnet build
       - name: Run test suite

--- a/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
+++ b/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>default</LangVersion>
+        <TargetFrameworks>net9.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="coverlet.collector" Version="6.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Organisationsnummer/Organisationsnummer.csproj
+++ b/Organisationsnummer/Organisationsnummer.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net46;net47;net5.0;net6.0;net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1;net7.0;net47;net48</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>default</LangVersion>
         <Company>Organisationsnummer</Company>
         <Authors>Johannes Tegnér, Organisationsnummer Contributors</Authors>
         <Description>Verify Swedish Organisation numbers.</Description>
@@ -33,6 +33,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Personnummer" Version="3.4.2" />
+      <PackageReference Include="Personnummer" Version="3.4.3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
**Type of change**

Dependency and target updates.

This PR removes support for dotnet framework 4.6 as well as two EOL versions of net (5, 6).

**Description**

Updated test to run for both net7 and net9.
Updated to latest version of personnummer.
Updated dev dependencies to latest versions.

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
