### PR TITLE
Drop net7 support (eol).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     name: Test dotnet
     steps:
       - uses: actions/checkout@v5
-      - name: Set up dotnet 7
+      - name: Set up dotnet 8
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
       - name: Set up dotnet 9
         uses: actions/setup-dotnet@v4
         with:

--- a/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
+++ b/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
@@ -4,11 +4,11 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>net9.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Organisationsnummer/Organisationsnummer.csproj
+++ b/Organisationsnummer/Organisationsnummer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;netstandard2.1;net7.0;net47;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1;net47;net48</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <Company>Organisationsnummer</Company>


### PR DESCRIPTION
**Description**

Removes dotnet7 from build and tests.

**Motivation**

net7 reached EOL about a year ago, no real need to keep it in the build.

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
