### PR TITLE
Updated targets to target net8-10, standard and fx4.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,20 +7,35 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-fx:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up dotnet ${{ matrix.version }}.
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+      - name: Build
+        run: dotnet build --framework net48
+      - name: Run test suite
+        run: dotnet test --framework net48
+  test-net:
+    strategy:
+      matrix:
+        version:
+          - "8.0"
+          - "9.0"
+          - "10.0"
     runs-on: ubuntu-latest
     name: Test dotnet
     steps:
       - uses: actions/checkout@v7
-      - name: Set up dotnet 8
+      - name: Set up dotnet ${{ matrix.version }}.
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
-      - name: Set up dotnet 10
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
+          dotnet-version: "${{ matrix.version }}.x"
       - name: Build
-        run: dotnet build
+        run: dotnet build --framework net${{ matrix.version }}
       - name: Run test suite
-        run: dotnet test
+        run: dotnet test --framework net${{ matrix.version }}

--- a/Organisationsnummer.Tests/DataProvider.cs
+++ b/Organisationsnummer.Tests/DataProvider.cs
@@ -3,23 +3,24 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Organisationsnummer.Tests;
 
 public struct OrganisationsnummerData
 {
-    [JsonProperty("input")]
+    [JsonPropertyName("input")]
     public string Input { get; set; }
-    [JsonProperty("long_format")]
+    [JsonPropertyName("long_format")]
     public string LongFormat { get; set; }
-    [JsonProperty("short_format")]
+    [JsonPropertyName("short_format")]
     public string ShortFormat { get; set; }
-    [JsonProperty("valid")]
+    [JsonPropertyName("valid")]
     public bool Valid { get; set; }
-    [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public string Type { get; set; }
-    [JsonProperty("vat_number")]
+    [JsonPropertyName("vat_number")]
     public string VatNumber { get; set; }
 }
 
@@ -47,7 +48,7 @@ public class DataProvider : IEnumerable<object[]>
     static DataProvider()
     {
         var response = WebClient.GetStringAsync("https://raw.githubusercontent.com/organisationsnummer/meta/main/testdata/list.json").Result;
-        Data = JsonConvert.DeserializeObject<List<OrganisationsnummerData>>(response)!;
+        Data = JsonSerializer.Deserialize<List<OrganisationsnummerData>>(response)!;
     }
 
     protected IEnumerable<object[]> AsObject(Func<OrganisationsnummerData, bool> filter) => Data.Where(filter).Select(o => new object[] { o });

--- a/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
+++ b/Organisationsnummer.Tests/Organisationsnummer.Tests.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>net9.0;net8</TargetFrameworks>
+        <TargetFrameworks>net48;net10.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,6 +16,11 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.Json" Version="10.0.7" />
+    </ItemGroup>
+    
     <ItemGroup>
       <ProjectReference Include="..\Organisationsnummer\Organisationsnummer.csproj" />
     </ItemGroup>

--- a/Organisationsnummer/Organisationsnummer.csproj
+++ b/Organisationsnummer/Organisationsnummer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;netstandard2.1;net47;net48</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net48;net10.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <Company>Organisationsnummer</Company>


### PR DESCRIPTION
This PR removes direct target support for dotnet 4.7, while keeps netstandard 2.1
Both the project and test project is now targeting the same versions as Personnummer.